### PR TITLE
Removing unused orbs for now

### DIFF
--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -2,8 +2,6 @@
 version: 2.1
 orbs:
   aws-s3: circleci/aws-s3@1.0.15
-  queue: eddiewebb/queue@1.3.0
-  slack: circleci/slack@3.4.2
 
 variables:
   - &workspace /home/circleci/project
@@ -111,9 +109,6 @@ jobs:
 
       - store_artifacts:
           path: test-reports
-
-      # Requires the SLACK_WEBHOOK env var to be set
-      - slack/notify-on-failure
 
   build:
     docker:


### PR DESCRIPTION
These two orbs weren't actually being used right now add a lot of complexity.

The EddieWebb/Queue orb is especially painful as it requires you to be a Github Admin and allow access to 3rd party orbs in the CircleCI UI.