### PR TITLE
comment slack webhook for opt-in usage

### DIFF
--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -147,8 +147,8 @@ jobs:
           paths:
             - "node_modules"
 
-      # Requires the SLACK_WEBHOOK
-      - slack/notify-on-failure
+      # Requires the SLACK_WEBHOOK env var to be set
+      # - slack/notify-on-failure
 
   deploy:
     docker:

--- a/zero-module.yml
+++ b/zero-module.yml
@@ -22,7 +22,6 @@ parameters:
   - field: region
     label: Select AWS Region
     options:
-      - "us-west-1"
       - "us-west-2"
       - "us-east-1"
       - "us-east-2"


### PR DESCRIPTION
- backend repo's slack webhook is commenting out 
commenting out the frontend's slack webhook as well

- and removing regoin without eks ami 
https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html