### PR TITLE
remove stray import when no-auth is choosen

### DIFF
--- a/templates/src/components/Navigation.js
+++ b/templates/src/components/Navigation.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React<%if eq (index .Params `userAuth`) "yes" %>, { useContext }<% end %> from 'react'
 import { Link } from 'react-router-dom'
 <%if eq (index .Params `userAuth`) "yes" %> import { AuthContext } from '../context/AuthContext'  <% end %>
 import logo from '../commit-logo.png'

--- a/templates/src/pages/Dashboard.js
+++ b/templates/src/pages/Dashboard.js
@@ -1,9 +1,9 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { <%if eq (index .Params `userAuth`) "yes" %>useContext, <% end %>useEffect, useState } from 'react'
 
 import Card from '../components/Card'
 <%if eq (index .Params `userAuth`) "yes" %> import { AuthContext } from '../context/AuthContext'
-import AuthCheck from '../components/AuthCheck'<% end %>
-
+import AuthCheck from '../components/AuthCheck'
+<% end %>
 
 // This is an example of an authenticated only page
 // to showcase how you would implement a page that loads data from backend
@@ -17,8 +17,7 @@ const fetchDashboard = async(data) => new Promise((resolve) => {
   setTimeout(fakeFetchData, 500);
 })
 
-<%if eq (index .Params `userAuth`) "yes" %> 
-function Dashboard() {
+<%if eq (index .Params `userAuth`) "yes" %>function Dashboard() {
   const { state: authState } = useContext(AuthContext)
   const [state, setState] = useState({
     isLoading: true,
@@ -56,8 +55,7 @@ function Dashboard() {
     </AuthCheck>
   )
 }
-<% else if eq (index .Params `userAuth`) "no" %>
-function Dashboard () {
+<% else if eq (index .Params `userAuth`) "no" %>function Dashboard () {
   const [state, setState] = useState({
     isLoading: true,
     data: {},


### PR DESCRIPTION
when user auth is disabled, we dont need to import `useContext` or else the build step will fail 
as lint rules strictly prohibits unused imports 