### PR TITLE
gha: rerun workflow after AWS creds injected

### DIFF
--- a/scripts/gha-setup.sh
+++ b/scripts/gha-setup.sh
@@ -39,4 +39,12 @@ curl -XPUT "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/branches/$DEFA
 	"restrictions": null
 }'
 
+## Rerun github actions workflow, since the first time github action is ran there are no AWS credentials
+## so it will always fail, begining of this script we inject the AWS credentials, therefore now we can rerun the workflow
+MOST_RECENT_RUN_ID=$(curl -XGET --url "https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/actions/runs" \
+--header "Authorization: token $GITHUB_ACCESS_TOKEN" --header 'Content-Type: application/json' | jq -r ".workflow_runs[0].id")
+## Triggering the rerun
+curl -XPOST --url "https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/actions/runs/${MOST_RECENT_RUN_ID}/rerun" \
+--header "Authorization: token $GITHUB_ACCESS_TOKEN" --header 'Content-Type: application/json'
+
 echo "Github actions environment variables setup successfully."

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-      build_env: production
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     steps:
     - uses: actions/checkout@v2
     - name: Run Unit Tests
@@ -17,6 +17,10 @@ jobs:
     - run: |
         yarn
         yarn test --watchAll=false
+    - if: env.AWS_ACCESS_KEY_ID == null
+          run: |
+            echo "AWS Credentials not found, This is expected for the first run as the repo is provisioned then secrets are injected at a later step."
+            exit 1
   build:
       needs: unit-test
       runs-on: ubuntu-latest


### PR DESCRIPTION
in the circleCI pipeline it does not run until makefile sets up webhooks
but in GHA it runs as soon as zero create pushes the repo, during that
time it has no AWS credentials, so it will always fail