### PR TITLE
fix lint error for serverless auth routes

### DIFF
--- a/templates/src/routes/Auth.js
+++ b/templates/src/routes/Auth.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import { BrowserRouter as Switch, Route, Link } from 'react-router-dom'
 import Logout from '../pages/Auth/Logout'
-<%- if ne (index .Params `backendApplicationHosting`) "serverless" %>
+<%- if eq (index .Params `backendApplicationHosting`) "serverless" %>
 import Login from '../pages/Auth/Login'
+<% end %>
+<%- if ne (index .Params `backendApplicationHosting`) "serverless" %>
 import Auth from '../pages/Auth/Form'
 <% end %>
 


### PR DESCRIPTION
In serverless auth uses /login to redirect but in
EKS auth frontend load the forms from Kratos with CSRF in React

The import was misplaced, it should need the Login when its serverless
and need the Form when its using Kratos